### PR TITLE
Request for Adding Paper "Can Pruning Improve Reasoning? Revisiting Long-CoT Compression with Capability in Mind for Better Reasoning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,7 @@ However, despite these developments, a comprehensive survey on Long CoT is still
 <li><i><b>DAST: Difficulty-Adaptive Slow-Thinking for Large Reasoning Models</b></i>, Shen et al., <a href="https://arxiv.org/abs/2503.04472" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.03-red" alt="arXiv Badge"></a></li>
 <li><i><b>ThinkPrune: Pruning Long Chain-of-Thought of LLMs via Reinforcement Learning</b></i>, Hou et al., <a href="https://arxiv.org/abs/2504.01296" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.04-red" alt="arXiv Badge"></a></li>
 <li><i><b>Long-Short Chain-of-Thought Mixture Supervised Fine-Tuning Eliciting Efficient Reasoning in Large Language Models</b></i>, Yu et al., <a href="https://arxiv.org/abs/2505.03469" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
+<li><i><b>Can Pruning Improve Reasoning? Revisiting Long-CoT Compression with Capability in Mind for Better Reasoning</b></i>, Shang et al., <a href="https://arxiv.org/abs/2505.14582" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 </ul>
 
 


### PR DESCRIPTION
Thank you for your excellent and insightful survey—it’s an invaluable resource for the community.

We’d like to kindly suggest including the following paper:
<a href="https://arxiv.org/abs/2505.14582"><em>Can Pruning Improve Reasoning? Revisiting Long-CoT Compression with Capability in Mind for Better Reasoning</em></a>.

This work introduces Prune-on-Logic, a structure-aware method that converts chain-of-thought (CoT) into logic graphs and prunes low-utility reasoning steps based on model confidence. It achieves stronger alignment with small language models (SLMs).

It could be a valuable addition to the discussion on process feedback and reasoning evaluation.

Thank you for considering this suggestion—any feedback is appreciated!